### PR TITLE
Keyboard Input Fix

### DIFF
--- a/docs/tutorial/codebase.pde
+++ b/docs/tutorial/codebase.pde
@@ -431,10 +431,6 @@ abstract class Actor extends Positionable {
 
   // handle key presses
   void keyPressed(char key, int keyCode) {  
-    //this form of looping seems to not be supprted in firefox
-    /*for(int i: keyCodes) {
-      setIfTrue(keyCode, i); }
-    */
     for(int i=0;i<keyCodes.length;i++){
       setIfTrue(keyCode,keyCodes[i]);
     }
@@ -442,14 +438,9 @@ abstract class Actor extends Positionable {
     
   // handle key releases
   void keyReleased(char key, int keyCode) {
-    //this form of looping seems to not be supported in firefox
-    /*for(int i: keyCodes) {
-      unsetIfTrue(keyCode, i); 
-    }*/
     for(int i=0;i<keyCodes.length;i++){
       unsetIfTrue(keyCode,keyCodes[i]);
     }
-
   }
 
   /**

--- a/docs/tutorial/codebase.pde
+++ b/docs/tutorial/codebase.pde
@@ -430,14 +430,27 @@ abstract class Actor extends Positionable {
   }
 
   // handle key presses
-  void keyPressed(char key, int keyCode) {
-    for(int i: keyCodes) {
-      setIfTrue(keyCode, i); }}
-
+  void keyPressed(char key, int keyCode) {  
+    //this form of looping seems to not be supprted in firefox
+    /*for(int i: keyCodes) {
+      setIfTrue(keyCode, i); }
+    */
+    for(int i=0;i<keyCodes.length;i++){
+      setIfTrue(keyCode,keyCodes[i]);
+    }
+  }
+    
   // handle key releases
   void keyReleased(char key, int keyCode) {
-    for(int i: keyCodes) {
-      unsetIfTrue(keyCode, i); }}
+    //this form of looping seems to not be supported in firefox
+    /*for(int i: keyCodes) {
+      unsetIfTrue(keyCode, i); 
+    }*/
+    for(int i=0;i<keyCodes.length;i++){
+      unsetIfTrue(keyCode,keyCodes[i]);
+    }
+
+  }
 
   /**
    * Does the indicated x/y coordinate fall inside this drawable thing's region?

--- a/mario/codebase.pde
+++ b/mario/codebase.pde
@@ -431,10 +431,6 @@ abstract class Actor extends Positionable {
 
   // handle key presses
   void keyPressed(char key, int keyCode) {  
-    //this form of looping seems to not be supprted in firefox
-    /*for(int i: keyCodes) {
-      setIfTrue(keyCode, i); }
-    */
     for(int i=0;i<keyCodes.length;i++){
       setIfTrue(keyCode,keyCodes[i]);
     }
@@ -442,14 +438,9 @@ abstract class Actor extends Positionable {
     
   // handle key releases
   void keyReleased(char key, int keyCode) {
-    //this form of looping seems to not be supported in firefox
-    /*for(int i: keyCodes) {
-      unsetIfTrue(keyCode, i); 
-    }*/
     for(int i=0;i<keyCodes.length;i++){
       unsetIfTrue(keyCode,keyCodes[i]);
     }
-
   }
 
   /**

--- a/mario/codebase.pde
+++ b/mario/codebase.pde
@@ -430,14 +430,27 @@ abstract class Actor extends Positionable {
   }
 
   // handle key presses
-  void keyPressed(char key, int keyCode) {
-    for(int i: keyCodes) {
-      setIfTrue(keyCode, i); }}
-
+  void keyPressed(char key, int keyCode) {  
+    //this form of looping seems to not be supprted in firefox
+    /*for(int i: keyCodes) {
+      setIfTrue(keyCode, i); }
+    */
+    for(int i=0;i<keyCodes.length;i++){
+      setIfTrue(keyCode,keyCodes[i]);
+    }
+  }
+    
   // handle key releases
   void keyReleased(char key, int keyCode) {
-    for(int i: keyCodes) {
-      unsetIfTrue(keyCode, i); }}
+    //this form of looping seems to not be supported in firefox
+    /*for(int i: keyCodes) {
+      unsetIfTrue(keyCode, i); 
+    }*/
+    for(int i=0;i<keyCodes.length;i++){
+      unsetIfTrue(keyCode,keyCodes[i]);
+    }
+
+  }
 
   /**
    * Does the indicated x/y coordinate fall inside this drawable thing's region?

--- a/tests/manualCollision/codebase.pde
+++ b/tests/manualCollision/codebase.pde
@@ -423,10 +423,6 @@ abstract class Actor extends Positionable {
 
   // handle key presses
   void keyPressed(char key, int keyCode) {  
-    //this form of looping seems to not be supprted in firefox
-    /*for(int i: keyCodes) {
-      setIfTrue(keyCode, i); }
-    */
     for(int i=0;i<keyCodes.length;i++){
       setIfTrue(keyCode,keyCodes[i]);
     }
@@ -434,14 +430,9 @@ abstract class Actor extends Positionable {
     
   // handle key releases
   void keyReleased(char key, int keyCode) {
-    //this form of looping seems to not be supported in firefox
-    /*for(int i: keyCodes) {
-      unsetIfTrue(keyCode, i); 
-    }*/
     for(int i=0;i<keyCodes.length;i++){
       unsetIfTrue(keyCode,keyCodes[i]);
     }
-
   }
 
   /**

--- a/tests/manualCollision/codebase.pde
+++ b/tests/manualCollision/codebase.pde
@@ -422,14 +422,27 @@ abstract class Actor extends Positionable {
   }
 
   // handle key presses
-  void keyPressed(char key, int keyCode) {
-    for(int i: keyCodes) {
-      setIfTrue(keyCode, i); }}
-
+  void keyPressed(char key, int keyCode) {  
+    //this form of looping seems to not be supprted in firefox
+    /*for(int i: keyCodes) {
+      setIfTrue(keyCode, i); }
+    */
+    for(int i=0;i<keyCodes.length;i++){
+      setIfTrue(keyCode,keyCodes[i]);
+    }
+  }
+    
   // handle key releases
   void keyReleased(char key, int keyCode) {
-    for(int i: keyCodes) {
-      unsetIfTrue(keyCode, i); }}
+    //this form of looping seems to not be supported in firefox
+    /*for(int i: keyCodes) {
+      unsetIfTrue(keyCode, i); 
+    }*/
+    for(int i=0;i<keyCodes.length;i++){
+      unsetIfTrue(keyCode,keyCodes[i]);
+    }
+
+  }
 
   /**
    * Does the indicated x/y coordinate fall inside this drawable thing's region?

--- a/tests/tinyplatforms/codebase.pde
+++ b/tests/tinyplatforms/codebase.pde
@@ -423,10 +423,6 @@ abstract class Actor extends Positionable {
 
   // handle key presses
   void keyPressed(char key, int keyCode) {  
-    //this form of looping seems to not be supprted in firefox
-    /*for(int i: keyCodes) {
-      setIfTrue(keyCode, i); }
-    */
     for(int i=0;i<keyCodes.length;i++){
       setIfTrue(keyCode,keyCodes[i]);
     }
@@ -434,14 +430,9 @@ abstract class Actor extends Positionable {
     
   // handle key releases
   void keyReleased(char key, int keyCode) {
-    //this form of looping seems to not be supported in firefox
-    /*for(int i: keyCodes) {
-      unsetIfTrue(keyCode, i); 
-    }*/
     for(int i=0;i<keyCodes.length;i++){
       unsetIfTrue(keyCode,keyCodes[i]);
     }
-
   }
 
   /**

--- a/tests/tinyplatforms/codebase.pde
+++ b/tests/tinyplatforms/codebase.pde
@@ -422,14 +422,27 @@ abstract class Actor extends Positionable {
   }
 
   // handle key presses
-  void keyPressed(char key, int keyCode) {
-    for(int i: keyCodes) {
-      setIfTrue(keyCode, i); }}
-
+  void keyPressed(char key, int keyCode) {  
+    //this form of looping seems to not be supprted in firefox
+    /*for(int i: keyCodes) {
+      setIfTrue(keyCode, i); }
+    */
+    for(int i=0;i<keyCodes.length;i++){
+      setIfTrue(keyCode,keyCodes[i]);
+    }
+  }
+    
   // handle key releases
   void keyReleased(char key, int keyCode) {
-    for(int i: keyCodes) {
-      unsetIfTrue(keyCode, i); }}
+    //this form of looping seems to not be supported in firefox
+    /*for(int i: keyCodes) {
+      unsetIfTrue(keyCode, i); 
+    }*/
+    for(int i=0;i<keyCodes.length;i++){
+      unsetIfTrue(keyCode,keyCodes[i]);
+    }
+
+  }
 
   /**
    * Does the indicated x/y coordinate fall inside this drawable thing's region?


### PR DESCRIPTION
This fixes broken keyboard input for Mozilla Firefox.

There is some underlying problem in Processing.js or Firefox when looping through an array of ints using for(int i: keyCodes){}
